### PR TITLE
MessageId & CorrelationId

### DIFF
--- a/consumer_message.go
+++ b/consumer_message.go
@@ -52,6 +52,7 @@ func newConsumerMessage(m amqp.Delivery) ConsumerMessage {
 		DeliveryMode:    m.DeliveryMode,
 		Priority:        m.Priority,
 		CorrelationId:   m.CorrelationId,
+		MessageId: 		 m.MessageId,
 		ReplyTo:         m.ReplyTo,
 		Expiration:      m.Expiration,
 		Timestamp:       m.Timestamp,

--- a/rabbus.go
+++ b/rabbus.go
@@ -56,6 +56,8 @@ type (
 		ContentEncoding string
 		// MessageId the message id.
 		MessageId string
+		// CorrelationId the message correlation id
+		CorrelationId string
 		// ReplyTo the queue name you should reply to
 		ReplyTo string
 	}
@@ -97,7 +99,7 @@ type (
 		exDeclared map[string]struct{}
 		config
 		conDeclared int // conDeclared is a counter for the declared consumers
-		connected bool
+		connected   bool
 	}
 
 	// AMQP exposes a interface for interacting with AMQP broker
@@ -327,6 +329,7 @@ func (r *Rabbus) produce(m Message) {
 		Body:            m.Payload,
 		ReplyTo:         m.ReplyTo,
 		MessageId:       m.MessageId,
+		CorrelationId:   m.CorrelationId,
 	}
 
 	if _, err := r.breaker.Execute(func() (interface{}, error) {


### PR DESCRIPTION
Rabbus lacks a couple of necessary features for RPC server - correct procession of MessageId & CorrelationId.
 
MessageId was absent in ConsumerMessage initialization.
Also CorrelationId added to amqp.Publishing.